### PR TITLE
Issue-7 - Log when partial CSV configurations are detected

### DIFF
--- a/src/Survey123/AllHeadersMissingException.cs
+++ b/src/Survey123/AllHeadersMissingException.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Survey123
+{
+    public class AllHeadersMissingException : Exception
+    {
+        public AllHeadersMissingException(string message)
+            : base(message)
+        {
+        }
+    }
+}

--- a/src/Survey123/Parser.cs
+++ b/src/Survey123/Parser.cs
@@ -99,10 +99,22 @@ namespace Survey123
                             HeaderMap = validator.BuildHeaderMap(Fields);
                             continue;
                         }
-                        catch (Exception)
+                        catch (Exception exception)
                         {
                             // Most Survey123 files have a header.
                             // So a problem mapping the header is a strong indicator that this CSV file is not intended for us.
+                            if (exception is AllHeadersMissingException)
+                            {
+                                // When all headers are missing, then we should exit without logging anything special.
+                                // We'll just let the other plugins have a turn
+                            }
+                            else
+                            {
+                                // Some of the headers matched, so log a warning before returning CannotParse.
+                                // This might be the only hint in the log that the survey configuration JSON is incorrect.
+                                Log.Info($"Partial headers detected: {exception.Message}");
+                            }
+
                             return ParseFileResult.CannotParse();
                         }
                     }

--- a/src/Survey123/Survey123.csproj
+++ b/src/Survey123/Survey123.csproj
@@ -46,6 +46,7 @@
     <Reference Include="System.Core" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AllHeadersMissingException.cs" />
     <Compile Include="DelayedAppender.cs" />
     <Compile Include="Survey.cs" />
     <Compile Include="Parser.cs" />

--- a/src/Survey123/SurveyLoader.cs
+++ b/src/Survey123/SurveyLoader.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.Serialization;
 using ServiceStack;
 
 namespace Survey123
@@ -13,9 +14,18 @@ namespace Survey123
             if (!File.Exists(path))
                 throw new Exception($"'{path}' does not exist.");
 
-            var survey = File.ReadAllText(path).FromJson<Survey>();
+            Survey survey;
 
-            if (IsEmpty(survey))
+            try
+            {
+                survey = File.ReadAllText(path).FromJson<Survey>();
+            }
+            catch (SerializationException)
+            {
+                return null;
+            }
+
+            if (survey == null || IsEmpty(survey))
                 return null;
 
             // Ensure that the alias dictionary is case insensitive

--- a/src/Survey123/SurveyValidator.cs
+++ b/src/Survey123/SurveyValidator.cs
@@ -68,9 +68,14 @@ namespace Survey123
                 .Where(column => !headerFields.Any(field => field.Equals(column.ColumnHeader, StringComparison.InvariantCultureIgnoreCase)))
                 .ToList();
 
+            var unknownHeadersMessage =
+                $"{"missing column".ToQuantity(unknownHeaderColumns.Count)}: {string.Join(", ", unknownHeaderColumns.Select(column => $"'{column.ColumnHeader}'"))}";
+
+            if (unknownHeaderColumns.Count == headerColumns.Count)
+                throw new AllHeadersMissingException(unknownHeadersMessage);
+
             if (unknownHeaderColumns.Any())
-                ThrowConfigurationException(
-                    $"{"missing column".ToQuantity(unknownHeaderColumns.Count)}: {string.Join(", ", unknownHeaderColumns.Select(column => $"'{column.ColumnHeader}'"))}");
+                ThrowConfigurationException(unknownHeadersMessage);
 
             var indexedColumns = columnDefinitions
                 .Where(c => c.ColumnIndex.HasValue)


### PR DESCRIPTION
We need some way to indicate that the CSV files being parsed are missing some expected header fields.

This will occur when a survey is changed on ESRI but the survey's JSON configuration has not been updated.

The plugin still needs to ignore the CSV file with CannotParse, and let other plugins have a try.

But when only some of the headers are found, log a message.